### PR TITLE
Fix for search.json broken link

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -47,7 +47,7 @@ const addGovUkEleventyPlugin = (eleventyConfig) => {
   const isSubDirectory = eleventyConfig.globalData.isSubDirectory || false;
   // https://govuk-eleventy-plugin.x-govuk.org/get-started/options/#options-for-search-object
   const search = {
-    indexPath: `${pathPrefix}search-index.json`,
+    indexPath: `search-index.json`,
     sitemapPath: "/sitemap",
   };
   // https://govuk-eleventy-plugin.x-govuk.org/get-started/options/#options-for-header-object

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "start:gh-pages": "GITHUB_ACTIONS=true eleventy --serve --quiet",
     "preserve": "npm run build",
     "serve": "http-server ./_site",
-    "test": "standard"
+    "test": "standard",
+    "test:gh-pages": "GITHUB_ACTIONS=true GITHUB_REF=\"refs/heads/main\" npm run build && mkdir -p _site/extract-alpha && cp -rp _site/* _site/extract-alpha/ && GITHUB_ACTIONS=true GITHUB_REF=\"refs/heads/main\" http-server ./_site"
   },
   "dependencies": {
     "@11ty/eleventy": "^3.0.0",


### PR DESCRIPTION
There is one setting `isProduction` that we only set on gh-pages deployments which we don't set in development because it points everything to the github files not the local ones. 

I'd included the `pathPrefix` (extract-alpha) in the `search.json` config as part of https://github.com/digital-land/extract-alpha/pull/212 which worked locally because `pathPrefix` set locally using `isSubDirectory` flag. I hadn't realised that was one of the urls setting the url field in the eleventy gov uk config would affect. 

This PR fixes that I've tested and verified it on my own fork and gh-pages deployment.